### PR TITLE
[Fix] Correct calculation for t.Med

### DIFF
--- a/stats/sink.go
+++ b/stats/sink.go
@@ -136,7 +136,7 @@ func (t *TrendSink) Calc() {
 
 	// The median of an even number of values is the average of the middle two.
 	if (t.Count & 0x01) == 0 {
-		t.Med = (t.Med + t.Values[(t.Count/2)-1]) / 2
+		t.Med = (t.Values[(t.Count/2)-1] + t.Values[(t.Count/2)]) / 2
 	} else {
 		t.Med = t.Values[t.Count/2]
 	}


### PR DESCRIPTION
When t.Count is even, t.Med should be half the sum of the two middle values in t.Values.